### PR TITLE
Add documentation to firewall collector

### DIFF
--- a/src/fw.c
+++ b/src/fw.c
@@ -138,6 +138,15 @@ int parse_options(int argc, char **argv)
 			                "At least one rule must be specified; all will be evaluated\n"
 			                "together, in parallel\n"
 			                "You may need to quote these, if <comment> contains spaces.\n"
+			                "\n"
+			                "To add a comment to an iptable rule you will need add the\n"
+			                "following command line switches to your iptables call\n"
+			                "    -m comment --comment \"limit ssh access\"\n"
+			                "A full example:\n"
+			                "    iptables -A INPUT -j DROP -p tcp --dport 22 -m comment --comment \"limit ssh access\"\n"
+			                "\n"
+			                "EXAMPLE:\n"
+			                "    fw filter:INPUT:\"limit ssh access\"\n"
 			                "\n");
 			exit(0);
 		}


### PR DESCRIPTION
Recently I was looking for away to track network traffic at a more
granular level. So I looked into the bag of tricks that bolo-collectors
has and found there was an iptables hook. After I did a little research
I learned that the kernel will track packet and byte count of an iptables
rule. neat!

Thus, I endevored to use the iptables collector, aptly named fw. After,
much trial and error and frustration, I learned the table rule needs to
have an attached comment. After adding said comments I quickly flushed
out all the parameters I need.

TLDR:
This commit adds standard help output to the firewall collector to help
setup iptables for collection.